### PR TITLE
fix RuntimeError for Pool

### DIFF
--- a/scripts/align.py
+++ b/scripts/align.py
@@ -110,13 +110,14 @@ def work(i):  # a single work
         print('%s fails!' % img_names[i])
 
 
-pool = Pool(args.n_worker)
-name_landmark_strs = list(tqdm.tqdm(pool.imap(work, range(len(img_names))), total=len(img_names)))
-pool.close()
-pool.join()
+if __name__ == '__main__':
+    pool = Pool(args.n_worker)
+    name_landmark_strs = list(tqdm.tqdm(pool.imap(work, range(len(img_names))), total=len(img_names)))
+    pool.close()
+    pool.join()
 
-landmarks_path = os.path.join(save_dir, 'landmark.txt')
-with open(landmarks_path, 'w') as f:
-    for name_landmark_str in name_landmark_strs:
-        if name_landmark_str:
-            f.write(name_landmark_str + '\n')
+    landmarks_path = os.path.join(save_dir, 'landmark.txt')
+    with open(landmarks_path, 'w') as f:
+        for name_landmark_str in name_landmark_strs:
+            if name_landmark_str:
+                f.write(name_landmark_str + '\n')


### PR DESCRIPTION
If you don't put Pool in __main__ that would cause it to execute multiple times and ran into this problem.

```
RuntimeError: 
        An attempt has been made to start a new process before the
        current process has finished its .

        This probably means that you are not using fork to start your
        child processes and you have forgotten to use the proper idiom
        in the main module:

            if __name__ == '__main__':
                freeze_support()
                ...

        The "freeze_support()" line can be omitted if the program
        is not going to be frozen to produce an executable.
```